### PR TITLE
Revert "Bump rack from 2.0.5 to 2.2.3"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
       activesupport (>= 3.1)
     parallel (1.10.0)
     public_suffix (2.0.5)
-    rack (2.2.3)
+    rack (2.0.5)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)


### PR DESCRIPTION
Reverts cfpb/hmda-platform-api-docs#20

- Bumping Rack to v2.2.3 introduces a build error for a couple of stylesheets.  Needs further investigation.
```
Content-Length header was 12068, but should be 12080
```

Stack trace:
```
Content-Length header was 4416, but should be 4428
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rack-2.2.3/lib/rack/lint.rb:21:in `assert'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rack-2.2.3/lib/rack/lint.rb:738:in `verify_content_length'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rack-2.2.3/lib/rack/lint.rb:762:in `each'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rack-2.2.3/lib/rack/response.rb:277:in `buffered_body!'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rack-2.2.3/lib/rack/mock.rb:191:in `initialize'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rack-2.2.3/lib/rack/mock.rb:85:in `new'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rack-2.2.3/lib/rack/mock.rb:85:in `request'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rack-2.2.3/lib/rack/mock.rb:57:in `get'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/middleman-core-4.2.1/lib/middleman-core/builder.rb:232:in `block in output_resource'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.0.1/lib/active_support/notifications.rb:166:in `instrument'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/middleman-core-4.2.1/lib/middleman-core/util.rb:21:in `instrument'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/middleman-core-4.2.1/lib/middleman-core/builder.rb:225:in `output_resource'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/contracts-0.13.0/lib/contracts/method_reference.rb:43:in `send_to'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/contracts-0.13.0/lib/contracts/call_with.rb:76:in `call_with'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/contracts-0.13.0/lib/contracts/method_handler.rb:138:in `block in redefine_method'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/parallel-1.10.0/lib/parallel.rb:462:in `call_with_index'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/parallel-1.10.0/lib/parallel.rb:433:in `process_incoming_jobs'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/parallel-1.10.0/lib/parallel.rb:415:in `block in worker'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/parallel-1.10.0/lib/parallel.rb:406:in `fork'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/parallel-1.10.0/lib/parallel.rb:406:in `worker'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/parallel-1.10.0/lib/parallel.rb:397:in `block in create_workers'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/parallel-1.10.0/lib/parallel.rb:396:in `each'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/parallel-1.10.0/lib/parallel.rb:396:in `each_with_index'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/parallel-1.10.0/lib/parallel.rb:396:in `create_workers'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/parallel-1.10.0/lib/parallel.rb:338:in `work_in_processes'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/parallel-1.10.0/lib/parallel.rb:252:in `map'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/middleman-core-4.2.1/lib/middleman-core/builder.rb:137:in `output_resources'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/contracts-0.13.0/lib/contracts/method_reference.rb:43:in `send_to'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/contracts-0.13.0/lib/contracts/call_with.rb:76:in `call_with'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/contracts-0.13.0/lib/contracts/method_handler.rb:138:in `block in redefine_method'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/middleman-core-4.2.1/lib/middleman-core/builder.rb:97:in `block in prerender_css'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.0.1/lib/active_support/notifications.rb:166:in `instrument'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/middleman-core-4.2.1/lib/middleman-core/util.rb:21:in `instrument'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/middleman-core-4.2.1/lib/middleman-core/builder.rb:95:in `prerender_css'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/contracts-0.13.0/lib/contracts/method_reference.rb:43:in `send_to'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/contracts-0.13.0/lib/contracts/call_with.rb:76:in `call_with'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/contracts-0.13.0/lib/contracts/method_handler.rb:138:in `block in redefine_method'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/middleman-core-4.2.1/lib/middleman-core/builder.rb:65:in `block in run!'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.0.1/lib/active_support/notifications.rb:166:in `instrument'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/middleman-core-4.2.1/lib/middleman-core/util.rb:21:in `instrument'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/middleman-core-4.2.1/lib/middleman-core/builder.rb:64:in `run!'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/contracts-0.13.0/lib/contracts/method_reference.rb:43:in `send_to'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/contracts-0.13.0/lib/contracts/call_with.rb:76:in `call_with'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/contracts-0.13.0/lib/contracts/method_handler.rb:138:in `block in redefine_method'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/middleman-cli-4.2.1/lib/middleman-cli/build.rb:80:in `block in build'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.0.1/lib/active_support/notifications.rb:166:in `instrument'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/middleman-core-4.2.1/lib/middleman-core/util.rb:21:in `instrument'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/middleman-cli-4.2.1/lib/middleman-cli/build.rb:79:in `build'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.19.4/lib/thor/invocation.rb:133:in `block in invoke_all'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.19.4/lib/thor/invocation.rb:133:in `each'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.19.4/lib/thor/invocation.rb:133:in `map'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.19.4/lib/thor/invocation.rb:133:in `invoke_all'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.19.4/lib/thor/group.rb:232:in `dispatch'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.19.4/lib/thor/invocation.rb:115:in `invoke'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.19.4/lib/thor.rb:40:in `block in register'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/middleman-cli-4.2.1/bin/middleman:70:in `<top (required)>'
~/.rbenv/versions/2.4.1/bin/middleman:22:in `load'
~/.rbenv/versions/2.4.1/bin/middleman:22:in `<top (required)>'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.17.3/lib/bundler/cli/exec.rb:74:in `load'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.17.3/lib/bundler/cli/exec.rb:74:in `kernel_load'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.17.3/lib/bundler/cli/exec.rb:28:in `run'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.17.3/lib/bundler/cli.rb:463:in `exec'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.17.3/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.17.3/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.17.3/lib/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.17.3/lib/bundler/cli.rb:27:in `dispatch'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.17.3/lib/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.17.3/lib/bundler/cli.rb:18:in `start'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.17.3/exe/bundle:30:in `block in <top (required)>'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.17.3/lib/bundler/friendly_errors.rb:124:in `with_friendly_errors'
~/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.17.3/exe/bundle:22:in `<top (required)>'
~/.rbenv/versions/2.4.1/bin/bundle:22:in `load'
~/.rbenv/versions/2.4.1/bin/bundle:22:in `<main>'
```
