### PR TITLE
Filing summary endpoint signature

### DIFF
--- a/source/includes/_filing_api.md.erb
+++ b/source/includes/_filing_api.md.erb
@@ -643,7 +643,7 @@ curl -X GET \
  | |
 ---|---
 Method | `GET`
-Endpoint | `<%= config[:filingapihost] %>/{{year}}/submissions/{{sequenceNumber}}/sign`
+Endpoint | `<%= config[:filingapihost] %>/v2/filing/institutions/{{lei}}/filings/{{year}}/submissions/{{sequenceNumber}}/summary`
 Headers | `Authorization: Bearer {{access_token}}`
 
 ## Quarterly Filing

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -446,7 +446,7 @@ html, body {
       vertical-align: top;
       line-height: 1.6;
       code {
-        white-space: nowrap;
+        word-break: break-all;
       }
     }
 


### PR DESCRIPTION
Closes #49 

- Fix mismatch between endpoint and example.
- Wrap the text content of \<code\> blocks to allows users access to the full text without needing to scroll.

before|after
---|----
<img width="1832" alt="Screen Shot 2021-12-19 at 1 09 27 AM" src="https://user-images.githubusercontent.com/2592907/146668227-728349a0-9a54-49c0-aa1c-306054958166.png">|<img width="1832" alt="Screen Shot 2021-12-19 at 1 09 04 AM" src="https://user-images.githubusercontent.com/2592907/146668233-9e8560ef-a29a-47f0-a930-772db9c54e6e.png">

